### PR TITLE
Update documentation about es_conn_timeout

### DIFF
--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -129,7 +129,7 @@ The environment variable ``ES_USE_SSL`` will override this field.
 
 ``es_send_get_body_as``: Optional; Method for querying Elasticsearch - ``GET``, ``POST`` or ``source``. The default is ``GET``
 
-``es_conn_timeout``: Optional; sets timeout for connecting to and reading from ``es_host``; defaults to ``10``.
+``es_conn_timeout``: Optional; sets timeout for connecting to and reading from ``es_host``; defaults to ``20``.
 
 ``rules_folder``: The name of the folder which contains rule configuration files. ElastAlert will load all
 files in this folder, and all subdirectories, that end in .yaml. If the contents of this folder change, ElastAlert will load, reload


### PR DESCRIPTION
It incorrectly states that it defaults to 10 seconds. It defaults to 20 seconds. See below

https://github.com/Yelp/elastalert/blob/master/elastalert/util.py#L321